### PR TITLE
Create Alias

### DIFF
--- a/setup
+++ b/setup
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Function to set up an alias for the tasks
+main()
+{
+    # Get the current script's directory and store it in the variable DIR
+    DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+    # Add an alias to the ~/.bashrc file for tasks
+    # The alias changes the directory to the script's directory, runs a Python script, and then changes back to the home directory
+    echo "alias tarefas='cd $DIR && python3 $DIR/ToDo_List_Terminal/__main__.py && cd ~/'" >> ~/.bashrc
+}
+
+# Call the main function
+main


### PR DESCRIPTION
### Description

Added a shell script for creating a convenient alias in Linux.

### Changes Made

- Added a new shell script named `setup`.
- The script sets up an alias named `tarefas` for easier task management.

### Usage

1. Run the script: `./setup´
2. Use the new alias: `tarefas`